### PR TITLE
Fixed invalid (culture variant) double parsing for rate-limit headers…

### DIFF
--- a/src/Disqord.Rest/Client/Requests/RateLimiting/RateLimit.cs
+++ b/src/Disqord.Rest/Client/Requests/RateLimiting/RateLimit.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using System.Globalization;
 using System.Linq;
 using System.Net.Http.Headers;
 
@@ -36,10 +37,10 @@ namespace Disqord.Rest
             if (headers.TryGetValues("X-RateLimit-Remaining", out values) && int.TryParse(values.First(), out var remaining))
                 Remaining = remaining;
 
-            if (headers.TryGetValues("X-RateLimit-Reset", out values) && double.TryParse(values.First(), out var resetsAt))
+            if (headers.TryGetValues("X-RateLimit-Reset", out values) && double.TryParse(values.First(), NumberStyles.AllowDecimalPoint, NumberFormatInfo.InvariantInfo, out var resetsAt))
                 ResetsAt = DateTimeOffset.UnixEpoch + TimeSpan.FromSeconds(resetsAt);
 
-            if (headers.TryGetValues("X-RateLimit-Reset-After", out values) && double.TryParse(values.First(), out var resetsAfter))
+            if (headers.TryGetValues("X-RateLimit-Reset-After", out values) && double.TryParse(values.First(), NumberStyles.AllowDecimalPoint, NumberFormatInfo.InvariantInfo, out var resetsAfter))
                 ResetsAfter = TimeSpan.FromSeconds(resetsAfter);
 
             if (headers.TryGetValues("X-RateLimit-Bucket", out values))


### PR DESCRIPTION
…. (#13)

* Fixing RateLimit.cs

Currently this class is broken, double.TryParsing is not parsing correctly the headers which leads to an unhandled exception to be thrown, this is because it ignores the dot based on the current culture as it wasn't specified to allow them. This issue causes TimeSpan to overflow, because "1582246711.602" gets parsed into 1582246711602 instead of 1582246711.602 making it to add over 50k years instead of 50.

this issue also happens with X-RateLimit-Reset-After to have a wrong value.

* Update RateLimit.cs

Now fixed for any culture